### PR TITLE
Push map_partitions in awkward mixins back to the user

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -921,7 +921,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         to map_partitions.
         """
         if hasattr(self._meta, method_name):
-            return getattr(self._meta, method_name)(*args, dask_array=self, **kwargs)
+            return getattr(self._meta, method_name)(
+                *args, __dask_array__=self, **kwargs
+            )
         raise AttributeError(
             f"Method {method_name} is not available to this collection."
         )
@@ -932,13 +934,13 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         if a user follows the pattern:
 
         class SomeMixin:
-            def get_the_property(self, dask_array = None):
+            def get_the_property(self, __dask_array__ = None):
                 ...
 
             the_property = property(get_the_property)
 
         This pattern is caught and reissued as a method call to the "get_the_property"
-        method, passing self as dask_array.
+        method, passing self as __dask_array__.
         """
         if hasattr(self._meta.__class__, property_name):
             if hasattr(self._meta.__class__, f"get_{property_name}"):

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -921,7 +921,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         to map_partitions.
         """
         if hasattr(self._meta, method_name):
-            return getattr(self._meta, method_name)(*args, **kwargs)
+            return getattr(self._meta, method_name)(*args, dask_array=self, **kwargs)
         raise AttributeError(
             f"Method {method_name} is not available to this collection."
         )
@@ -943,14 +943,12 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         if hasattr(self._meta.__class__, property_name):
             if hasattr(self._meta.__class__, f"get_{property_name}"):
                 return self._call_behavior_method(
-                    f"get_{property_name}", dask_array=self
+                    f"get_{property_name}",
                 )
             return self.map_partitions(
                 _BehaviorPropertyFn(property_name),
                 label=hyphenize(property_name),
             )
-        elif hasattr(self._meta, f"get_{property_name}"):
-            return getattr(self._meta, property_name)(self)
         raise AttributeError(
             f"Property {property_name} is not available to this collection."
         )

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -942,6 +942,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
         This pattern is caught and reissued as a method call to the "get_the_property"
         method, passing self as __dask_array__.
+        
+        If get_the_property is not defined, and the_property is decorated with
+        @property, then then no calling context is needed and the property is
+        mapped directly.
         """
         if hasattr(self._meta.__class__, property_name):
             if hasattr(self._meta.__class__, f"get_{property_name}"):

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -921,8 +921,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         to map_partitions.
         """
         if hasattr(self._meta, method_name):
+            array_context = kwargs.pop("__dask_array__", self)
             return getattr(self._meta, method_name)(
-                *args, __dask_array__=self, **kwargs
+                *args, __dask_array__=array_context, **kwargs
             )
         raise AttributeError(
             f"Method {method_name} is not available to this collection."

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -22,9 +22,9 @@ class _ClassMethodFn:
 
 @ak.mixin_class(behaviors)
 class Point:
-    def distance(self, other, dask_array=None):
-        if dask_array is not None:
-            return dask_array.map_partitions(
+    def distance(self, other, __dask_array__=None):
+        if __dask_array__ is not None:
+            return __dask_array__.map_partitions(
                 _ClassMethodFn("distance"),
                 other,
             )
@@ -35,9 +35,9 @@ class Point:
         return self.x * self.x
 
     @ak.mixin_class_method(np.abs)
-    def point_abs(self, dask_array=None):
-        if dask_array is not None:
-            return dask_array.map_partitions(
+    def point_abs(self, __dask_array__=None):
+        if __dask_array__ is not None:
+            return __dask_array__.map_partitions(
                 _ClassMethodFn("point_abs"),
             )
         return np.sqrt(self.x**2 + self.y**2)

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -97,9 +97,9 @@ class _ClassMethodFn:
 
 @ak.mixin_class(behaviors)
 class Point:
-    def distance(self, other, dask_array=None):
-        if dask_array is not None:
-            return dask_array.map_partitions(
+    def distance(self, other, __dask_array__=None):
+        if __dask_array__ is not None:
+            return __dask_array__.map_partitions(
                 _ClassMethodFn("distance"),
                 other,
             )
@@ -110,9 +110,9 @@ class Point:
         return self.x * self.x
 
     @ak.mixin_class_method(np.abs)
-    def point_abs(self, dask_array=None):
-        if dask_array is not None:
-            return dask_array.map_partitions(
+    def point_abs(self, __dask_array__=None):
+        if __dask_array__ is not None:
+            return __dask_array__.map_partitions(
                 _ClassMethodFn("point_abs"),
             )
         return np.sqrt(self.x**2 + self.y**2)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -298,10 +298,7 @@ def test_copy(daa):
         np.float64,
         np.complex64,
         np.complex128,
-        pytest.param(
-            np.datetime64,
-            marks=pytest.mark.xfail(reason="specific to generic units in numpy"),
-        ),
+        np.datetime64,
         np.timedelta64,
         np.float16,
     ],


### PR DESCRIPTION
Allow properies with out-of-class state access.

This PR makes it so that the handling of dask is given to the user directly so they have more freedom in designing their user-facing interfaces.

The calling-array context is passed to methods as `__dask_array__` which is appended to the list of kwargs to the mixin function.